### PR TITLE
Remove contacts-frontend definitions

### DIFF
--- a/gds/packages/govuk.scm
+++ b/gds/packages/govuk.scm
@@ -199,24 +199,6 @@ proxies requests to some upstream")
      (home-page "https://github.com/alphagov/contacts-admin"))
    #:extra-inputs (list mariadb)))
 
-(define-public contacts-frontend
-  (package-with-bundler
-   (bundle-package
-    (hash (base32 "0pabhmanjs1m0b5zdkwng7p2fpjmwjipvwraimywyq8dikvxl8jh")))
-   (package
-     (name "contacts-frontend")
-     (version "release_73")
-     (source
-      (github-archive
-       #:repository name
-       #:commit-ish version
-       #:hash (base32 "00bvw3jadh4c97g7j14q1p4m2q9bygxbb5xkvqns5kgxyys7d762")))
-     (build-system rails-build-system)
-     (synopsis "")
-     (description "")
-     (license license:expat)
-     (home-page "https://github.com/alphagov/contacts-frontend"))))
-
 (define-public content-api
   (package-with-bundler
    (bundle-package

--- a/gds/services/govuk.scm
+++ b/gds/services/govuk.scm
@@ -429,36 +429,6 @@
            (database "contacts_production")))))
 
 ;;;
-;;; Contacts Frontend
-;;;
-
-(define-public contacts-frontend-service-type
-  (make-rails-app-using-plek-and-signon-service-type 'contacts-frontend))
-
-(define-public contacts-frontend-service
-  (service
-   contacts-frontend-service-type
-   (list (shepherd-service
-           (inherit default-shepherd-service)
-           (provision '(contacts-frontend))
-           (requirement '(publishing-api whitehall-admin signon)))
-          (plek-config) (rails-app-config) contacts-frontend
-          (service-startup-config))))
-
-(define-public draft-contacts-frontend-service-type
-  (make-rails-app-using-plek-and-signon-service-type 'draft-contacts-frontend))
-
-(define-public draft-contacts-frontend-service
-  (service
-   draft-contacts-frontend-service-type
-   (list (shepherd-service
-           (inherit default-shepherd-service)
-           (provision '(draft-contacts-frontend))
-           (requirement '(publishing-api whitehall-admin signon)))
-          (plek-config) (rails-app-config) contacts-frontend
-          (service-startup-config))))
-
-;;;
 ;;; Content Performance Manager
 ;;;
 
@@ -1871,7 +1841,6 @@
    calculators-service
    calendars-service
    collections-service
-   contacts-frontend-service
    design-principles-service
    email-alert-frontend-service
    feedback-service
@@ -1890,7 +1859,6 @@
 (define-public draft-frontend-services
   (list
    draft-collections-service
-   draft-contacts-frontend-service
    draft-email-alert-frontend-service
    draft-frontend-service
    draft-government-frontend-service


### PR DESCRIPTION
# Description

`contacts-frontend` is being retired with `government-frontend` having replaced it, this PR removes app definitions.