### PR TITLE
Remove specialist-frontend and multipage-frontend

### DIFF
--- a/gds/packages/govuk.scm
+++ b/gds/packages/govuk.scm
@@ -794,24 +794,6 @@ service setup.")
     (license "")
     (home-page "https://github.com/alphagov/metadata-api")))
 
-(define-public multipage-frontend
-  (package-with-bundler
-   (bundle-package
-    (hash (base32 "0h7g4s2yzwp9a77fd5rpwj7sbsj0vfy0216g98j2175nx75b8ic7")))
-   (package
-     (name "multipage-frontend")
-     (version "release_56")
-     (source
-      (github-archive
-       #:repository name
-       #:commit-ish version
-       #:hash (base32 "17wybzky3ykcrfgxrphiqgbnnhh2lm4cxa7vkrac55i3xwcrsvca")))
-     (build-system rails-build-system)
-     (synopsis "")
-     (description "")
-     (license #f)
-     (home-page "https://github.com/alphagov/multipage-frontend"))))
-
 (define-public need-api
   (package-with-bundler
    (bundle-package
@@ -1191,25 +1173,6 @@ content, as well as broadcasting changes to a message queue.")
      (description "")
      (license #f)
      (home-page "https://github.com/alphagov/smart-answers"))))
-
-(define-public specialist-frontend
-  (package-with-bundler
-   (bundle-package
-    (hash (base32 "12nc71g807ryi5ywvzcj8r0c5fd3fyc8rx1nj32m3kk5xp07gwx5")))
-   (package
-     (name "specialist-frontend")
-     (version "release_187")
-     (source
-      (github-archive
-       #:repository name
-       #:commit-ish version
-       #:hash (base32 "10xgf5pksq6q4rvnlwvi609p63fx4x13brn33xgrq40vbjybh7fj")))
-     (build-system rails-build-system)
-     (arguments `(#:precompile-rails-assets? #f))
-     (synopsis "")
-     (description "")
-     (license #f)
-     (home-page "https://github.com/alphagov/specialist-frontend"))))
 
 (define-public specialist-publisher
   (package-with-bundler

--- a/gds/services/govuk.scm
+++ b/gds/services/govuk.scm
@@ -785,40 +785,6 @@
            (database "manuals_publisher")))))
 
 ;;;
-;;; Multipage Frontend
-;;;
-
-(define-public multipage-frontend-service-type
-  (make-rails-app-using-plek-and-signon-service-type 'multipage-frontend))
-
-(define-public multipage-frontend-service
-  (service
-   multipage-frontend-service-type
-   (list (shepherd-service
-           (inherit default-shepherd-service)
-           (provision '(multipage-frontend))
-           (requirement '(content-store static)))
-          (plek-config) (rails-app-config) multipage-frontend
-          (service-startup-config)
-          (mongodb-connection-config
-           (database "multipage_frontend")))))
-
-(define-public draft-multipage-frontend-service-type
-  (make-rails-app-using-plek-and-signon-service-type 'draft-multipage-frontend))
-
-(define-public draft-multipage-frontend-service
-  (service
-   draft-multipage-frontend-service-type
-   (list (shepherd-service
-           (inherit default-shepherd-service)
-           (provision '(draft-multipage-frontend))
-           (requirement '(draft-content-store draft-static)))
-          (plek-config) (rails-app-config) multipage-frontend
-          (service-startup-config)
-          (mongodb-connection-config
-           (database "multipage_frontend")))))
-
-;;;
 ;;; Policy Publisher
 ;;;
 
@@ -1340,40 +1306,6 @@
          (plek-config) (rails-app-config) government-frontend)))
 
 ;;;
-;;; Specialist Frontend
-;;;
-
-(define-public specialist-frontend-service-type
-  (make-rails-app-using-plek-and-signon-service-type 'specialist-frontend))
-
-(define-public specialist-frontend-service
-  (service
-   specialist-frontend-service-type
-   (list (shepherd-service
-          (inherit default-shepherd-service)
-          (provision '(specialist-frontend))
-          (requirement '(content-store static)))
-         (service-startup-config
-          (environment-variables
-           '(("GOVUK_APP_NAME" . "specialist-frontend"))))
-         (plek-config) (rails-app-config) specialist-frontend)))
-
-(define-public draft-specialist-frontend-service-type
-  (make-rails-app-using-plek-and-signon-service-type 'draft-specialist-frontend))
-
-(define-public draft-specialist-frontend-service
-  (service
-   draft-specialist-frontend-service-type
-   (list (shepherd-service
-          (inherit default-shepherd-service)
-          (provision '(draft-specialist-frontend))
-          (requirement '(draft-content-store draft-static)))
-         (service-startup-config
-          (environment-variables
-           '(("GOVUK_APP_NAME" . "draft-specialist-frontend"))))
-         (plek-config) (rails-app-config) specialist-frontend)))
-
-;;;
 ;;; Content API
 ;;;
 
@@ -1879,10 +1811,8 @@
    info-frontend-service
    licence-finder-service
    manuals-frontend-service
-   multipage-frontend-service
    service-manual-frontend-service
    smart-answers-service
-   specialist-frontend-service
    static-service))
 
 (define-public draft-frontend-services
@@ -1892,10 +1822,8 @@
    draft-frontend-service
    draft-government-frontend-service
    draft-manuals-frontend-service
-   draft-multipage-frontend-service
    draft-service-manual-frontend-service
-   draft-static-service
-   draft-specialist-frontend-service))
+   draft-static-service))
 
 (define-public govuk-services
   (append

--- a/gds/systems/govuk/development.scm
+++ b/gds/systems/govuk/development.scm
@@ -53,8 +53,6 @@
                     (specialist-publisher . 53064)
                     (need-api . 53052)
                     (maslow . 53053)
-                    (specialist-frontend . 53065)
-                    (draft-specialist-frontend . 53066)
                     (government-frontend . 53090)
                     (draft-government-frontend . 53091)
                     (contentapi . 53022)


### PR DESCRIPTION
These apps are being retired.
Remove all references to both.

Part of:
https://trello.com/c/UM7aecOQ/194-final-stage-decomission-specialist-frontend-2
https://trello.com/c/AKjgW8yL/191-final-stage-decomission-multipage-frontend-2