### PR TITLE
Remove the Content API

### DIFF
--- a/gds/data/govuk/sources/govuk-puppet.scm
+++ b/gds/data/govuk/sources/govuk-puppet.scm
@@ -37,8 +37,7 @@
   `(("mongo-1.backend.integration"
      ("govuk_assets_production" . (,asset-manager-service-type))
      ("govuk_content_production" .
-      (,content-api-service-type
-       ,publisher-service-type
+      (,publisher-service-type
        ,specialist-publisher-service-type
        ,manuals-publisher-service-type))
      ("govuk_needs_production" . (,need-api-service-type))

--- a/gds/packages/govuk.scm
+++ b/gds/packages/govuk.scm
@@ -236,31 +236,6 @@ proxies requests to some upstream")
      (home-page "https://github.com/alphagov/contacts-admin"))
    #:extra-inputs (list mariadb)))
 
-(define-public content-api
-  (package-with-bundler
-   (bundle-package
-    (hash (base32 "1iaf3vyiff00sybr0ysqx20j68ml0kzzkb9sv05w4xy612shbyva")))
-   (package
-     (name "content-api")
-     (version "release_404")
-     (source
-      (github-archive
-       #:repository "govuk_content_api"
-       #:commit-ish version
-       #:hash (base32 "1j1gzhvdg7avvkq9ciw5x9k3lhr8fp42c78v6ra4q4dh3iqif1hk")))
-     (build-system rails-build-system)
-     (arguments
-      `(#:precompile-rails-assets? #f
-        #:phases
-        (modify-phases %standard-phases
-          (add-after 'install 'replace-mongoid.yml
-                     ,(replace-mongoid.yml #:path "/mongoid.yml")))))
-     (synopsis "")
-     (description "")
-     (license #f)
-     (home-page "https://github.com/alphagov/content-api"))
-   #:extra-inputs (list libffi)))
-
 (define-public content-performance-manager
   (package-with-bundler
    (bundle-package

--- a/gds/services/govuk.scm
+++ b/gds/services/govuk.scm
@@ -1306,31 +1306,6 @@
          (plek-config) (rails-app-config) government-frontend)))
 
 ;;;
-;;; Content API
-;;;
-
-(define govuk-content-database-connection
-  (mongodb-connection-config
-   (database "govuk_content_production")))
-
-(define-public content-api-service-type
-  (make-rails-app-using-plek-and-signon-service-type 'contentapi))
-
-(define-public content-api-service
-  (service
-   content-api-service-type
-   (list (shepherd-service
-          (inherit default-shepherd-service)
-          (provision '(contentapi))
-          (requirement '()))
-         (service-startup-config)
-         (signon-application
-          (name "Content API")
-          (supported-permissions '("signin" "access_unpublished")))
-         (plek-config) (rails-app-config) content-api
-         govuk-content-database-connection)))
-
-;;;
 ;;; Frontend
 ;;;
 
@@ -1343,7 +1318,7 @@
    (list (shepherd-service
           (inherit default-shepherd-service)
           (provision '(frontend))
-          (requirement '(contentapi static rummager content-store)))
+          (requirement '(static rummager content-store)))
          (service-startup-config)
          (plek-config) (rails-app-config) frontend)))
 
@@ -1356,7 +1331,7 @@
    (list (shepherd-service
           (inherit default-shepherd-service)
           (provision '(draft-frontend))
-          (requirement '(contentapi draft-static rummager draft-content-store)))
+          (requirement '(draft-static rummager draft-content-store)))
          (service-startup-config)
          (plek-config) (rails-app-config) frontend)))
 
@@ -1373,7 +1348,7 @@
    (list (shepherd-service
           (inherit default-shepherd-service)
           (provision '(publisher))
-          (requirement '(contentapi publishing-api frontend draft-frontend
+          (requirement '(publishing-api frontend draft-frontend
                          rummager signon)))
          (service-startup-config)
          (plek-config) (rails-app-config) publisher
@@ -1771,7 +1746,6 @@
    draft-content-store-service
    ;; email-alert-api-service Can't connect to Redis for some reason
    ;; email-alert-service-service Missing dependency on RabbitMQ
-   content-api-service
    need-api-service
    imminence-service
    publishing-api-service

--- a/gds/systems/govuk/development.scm
+++ b/gds/systems/govuk/development.scm
@@ -55,7 +55,6 @@
                     (maslow . 53053)
                     (government-frontend . 53090)
                     (draft-government-frontend . 53091)
-                    (contentapi . 53022)
                     (frontend . 53005)
                     (draft-frontend . 53007)
                     (rummager . 53009)


### PR DESCRIPTION
The [`content_api`](https://github.com/alphagov/govuk_content_api) has
been retired, and all content has been migrated to the
[`content_store`](https://github.com/alphagov/content-store).

Therefore, we can remove all references to the Content API, and rely
solely on the Content Store.

### Trello

https://trello.com/c/TsUsUwD7/153-remove-documentation-on-content-api
