### PR TITLE
Remove Need API

### DIFF
--- a/gds/data/govuk/sources/govuk-puppet.scm
+++ b/gds/data/govuk/sources/govuk-puppet.scm
@@ -41,7 +41,6 @@
       (,publisher-service-type
        ,specialist-publisher-service-type
        ,manuals-publisher-service-type))
-     ("govuk_needs_production" . (,need-api-service-type))
      ("imminence_production" . (,imminence-service-type))
      ("licence_finder_production" . (,licence-finder-service-type))
      ;;("manuals_publisher_production" . (,manuals-publisher-service-type))

--- a/gds/packages/govuk.scm
+++ b/gds/packages/govuk.scm
@@ -741,31 +741,6 @@ service setup.")
      (home-page "https://github.com/alphagov/maslow"))
    #:extra-inputs (list libffi)))
 
-(define-public need-api
-  (package-with-bundler
-   (bundle-package
-    (hash (base32 "0bvwysm8q8kbc70ajdhnicyssxm6qbjz4zl1mhnbir9z6dwzd2vg")))
-   (package
-     (name "need-api")
-     (version "release_146")
-     (source
-      (github-archive
-       #:repository "govuk_need_api"
-       #:commit-ish version
-       #:hash (base32 "1mgz29xmi4sgbbwal9z9rbb5f5drjgq5hj6kalbhvn8pin0glzqr")))
-     (build-system rails-build-system)
-     (arguments
-      `(#:precompile-rails-assets? #f
-        #:phases
-        (modify-phases %standard-phases
-          (add-after 'install 'replace-mongoid.yml
-                     ,(replace-mongoid.yml #:mongoid-version "3")))))
-     (synopsis "")
-     (description "")
-     (license #f)
-     (home-page "https://github.com/alphagov/need-api"))
-   #:extra-inputs (list libffi)))
-
 (define-public policy-publisher
   (package-with-bundler
    (bundle-package

--- a/gds/services/govuk.scm
+++ b/gds/services/govuk.scm
@@ -1604,28 +1604,6 @@
           (database "maslow")))))
 
 ;;;
-;;; Need API
-;;;
-
-(define-public need-api-service-type
-  (make-rails-app-using-plek-and-signon-service-type 'need-api))
-
-(define-public need-api-service
-  (service
-   need-api-service-type
-   (list (shepherd-service
-          (inherit default-shepherd-service)
-          (provision '(need-api))
-          (requirement '(publishing-api signon)))
-         (service-startup-config)
-         (signon-application
-          (name "Need API")
-          (supported-permissions '("signin" "write")))
-         (plek-config) (rails-app-config) need-api
-         (mongodb-connection-config
-          (database "govuk_needs_development")))))
-
-;;;
 ;;; Rummager
 ;;;
 
@@ -1810,7 +1788,6 @@
    draft-content-store-service
    ;; email-alert-api-service Can't connect to Redis for some reason
    ;; email-alert-service-service Missing dependency on RabbitMQ
-   need-api-service
    imminence-service
    publishing-api-service
    rummager-service

--- a/gds/systems/govuk/development.scm
+++ b/gds/systems/govuk/development.scm
@@ -55,7 +55,6 @@
                     (content-tagger . 53116)
                     (whitehall . 53020)
                     (specialist-publisher . 53064)
-                    (need-api . 53052)
                     (maslow . 53053)
                     (government-frontend . 53090)
                     (draft-government-frontend . 53091)


### PR DESCRIPTION
Need API is being retired so we're removing references to it.

For: https://trello.com/c/ClCFMBlG/217-retire-need-api