### PR TITLE
Offer help if aws cli tools are not installed

### DIFF
--- a/bin/govuk-aws
+++ b/bin/govuk-aws
@@ -100,12 +100,19 @@ get_aws_credentials() {
     fi
 }
 
+test_aws_cli_installed() {
+  if ! command -v aws 2>/dev/null; then
+    echo "You need to have the aws cli tool installed to run govuk aws.\r\nIt looks like you don't.\r\nPlease visit https://aws.amazon.com/cli/ for installation instructions."
+    exit 1
+  fi
+}
 
 if [ "$1" == "--profile" ]; then
     profile="$2"
     cache_directory="${XDG_CACHE_HOME-$HOME/.cache}/govuk-guix"
     cached_aws_credentials="$cache_directory/${profile}-aws-credentials"
 
+    test_aws_cli_installed
     get_aws_credentials
 
     if [ "$3" == "--export" ]; then


### PR DESCRIPTION
If you do not have the aws cli tools installed and you try to run
`govuk aws`, you'll be presented with an error.

Instead of erroring, offer some help to the user with a link to aws docs so they
can install the tools. Subsequently, exit early.