### PR TITLE
Remove Content Audit Tool

### DIFF
--- a/gds/data/govuk/sources/govuk-puppet-aws.scm
+++ b/gds/data/govuk/sources/govuk-puppet-aws.scm
@@ -34,8 +34,7 @@
 ;;;
 
 (define postgresql-extracts
-  `(("content_audit_tool_production" . (,content-audit-tool-service-type))
-    ("content_data_admin_production" . (,content-data-admin-service-type))
+  `(("content_data_admin_production" . (,content-data-admin-service-type))
     ("content_performance_manager_production" .
      (,content-data-api-service-type))
     ("content_tagger_production" . (,content-tagger-service-type))

--- a/gds/packages/govuk.scm
+++ b/gds/packages/govuk.scm
@@ -294,36 +294,6 @@ proxies requests to some upstream")
                         mariadb
                         openssl)))
 
-(define-public content-audit-tool
-  (package-with-bundler
-   (bundle-package
-    (hash (base32 "07iaj54qpfrzzxfwy1cr9vsrcszpx1j3qjrlpw0wsyz2vrmapr99")))
-   (package
-     (name "content-audit-tool")
-     (version "release_703")
-     (source
-      (github-archive
-       #:repository name
-       #:commit-ish version
-       #:hash (base32 "1gcyaqcaz6zqcq51kqx4rxs78sc99qs3n425drfq2ndf6m9vm103")))
-     (build-system rails-build-system)
-     (arguments
-      `(#:phases
-        (modify-phases %standard-phases
-          (add-before 'install 'add-govuk-admin-template-initialiser
-            ,govuk-admin-template-initialiser)
-          (add-after 'install 'replace-database.yml
-            ,(use-blank-database.yml))
-          (add-before 'check 'set-GOVUK_TEST_USE_SYSTEM_CHROMEDRIVER
-            (lambda _
-              (setenv "GOVUK_TEST_USE_SYSTEM_CHROMEDRIVER" "true")
-              #t)))))
-     (synopsis "")
-     (description "")
-     (license #f)
-     (home-page "https://github.com/alphagov/content-audit-tool"))
-   #:extra-inputs (list postgresql libffi)))
-
 (define-public content-data-admin
   (package-with-bundler
    (bundle-package

--- a/gds/services/govuk.scm
+++ b/gds/services/govuk.scm
@@ -365,43 +365,6 @@
             (database "content_performance_manager_production"))))))
 
 ;;;
-;;; Content Audit Tool
-;;;
-
-(define-public content-audit-tool-service-type
-  (service-type
-   (name 'content-audit-tool)
-   (extensions
-    (modify-service-extensions-for-signon-and-plek
-     name
-     (standard-rails-service-type-extensions name)))
-   (default-value
-     (list (shepherd-service
-            (inherit default-shepherd-service)
-            (provision '(content-audit-tool))
-            (requirement '(publishing-api whitehall signon)))
-           (sidekiq-config
-            (file "config/sidekiq.yml"))
-           (plek-config) (rails-app-config) content-audit-tool
-           (signon-application
-            (name "Content Audit Tool")
-            (supported-permissions '("signin")))
-           (signon-api-user
-            (name "Content Audit Tool")
-            (email "content-audit-tool@guix-dev.gov.uk")
-            (authorisation-permissions
-             (list
-              (cons
-               (signon-authorisation
-                (application-name "Publishing API"))
-               '("signin")))))
-           (service-startup-config)
-           (redis-connection-config)
-           (postgresql-connection-config
-            (user "content_audit_tool")
-            (database "content_audit_tool_production"))))))
-
-;;;
 ;;; Content Data Admin
 ;;;
 
@@ -2128,8 +2091,7 @@
   (service-group
    "Supporting Applications"
    "Applications to support GOV.UK"
-   (list (service content-audit-tool-service-type)
-         (service content-data-admin-service-type)
+   (list (service content-data-admin-service-type)
          (service content-data-api-service-type)
          (service link-checker-api-service-type)
          (service search-admin-service-type)


### PR DESCRIPTION
Content Audit Tool is a legacy application created before Content Data. It was used to help tag content - it shared a codebase with Content Performance Manager.

It is being retired as it should no longer be used, to clean up references to it in our codebase, and remove the need for developers to maintain it.

[Trello](https://trello.com/c/V6bXwwtx/1700-3-retire-content-audit-app)